### PR TITLE
Fix comment font having the wrong color

### DIFF
--- a/style.css
+++ b/style.css
@@ -184,7 +184,7 @@
     color: #fff !important;
   }
 
-  span.commtext,
+  div.commtext,
   p {
     color: #fff !important;
   }


### PR DESCRIPTION
It seems that sometime this year, Hacker News changed the comment box from span to div, making this style show the original font color (black).
This fixes it.